### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -2,6 +2,8 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
 name: Node.js CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/tisana/tic-tac-toe/security/code-scanning/1](https://github.com/tisana/tic-tac-toe/security/code-scanning/1)

To fix the issue, add an explicit `permissions` block to the workflow file. The best way to start is to set the permissions at the top level of the workflow (just below the `name:` field and above the `on:` field) so it applies to all jobs, unless a job sets its own. Given the steps included, the minimum required permission is to allow reading repository contents (for actions/checkout, which requires `contents: read`). No write permission is necessary for artifacts or for running builds or installation commands. Therefore, add the following block:

```yaml
permissions:
  contents: read
```

This should be placed after the `name: Node.js CI` line (line 4), before the `on:` trigger (line 6).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
